### PR TITLE
Initial block audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,28 @@
 SignalTimeout
-=======
-
+=============
 Notifies a timeout signal when no signals have been processed by this block for the defined `intervals`. A timeout signal is the last signal to enter the block with an added `group` attribute that specifies the group (default `None`) and a `timeout` attribute that is a python `datetime.timedelta` specifying the configured `interval` that triggered the signal.
 
-Group-by functionality will create timeout signals for each registered group. A signal needs to come in to the block to initialize a group and start emitting timeout signals.
-
-Repeatable timeouts are saved to persistence so that they continue to notify after a service restart.
-
 Properties
---------------
+----------
+- **backup_interval**: 
+- **group_by**: The value by which signals are grouped. Output signals will have `group` set to this value.
+- **intervals**: After a signal, if another one does not enter the block for this amount of time, emit a timeout signal.
+- **load_from_persistence**: If true, when the block is restarted it will restart with the previous amount of remaining time for the current interval
 
--   **intervals**:
-    -   **interval**: After a signal, if another one does not enter the block for this amount of time, emit a timeout signal.
-    -   **repeatable**: If `True`, a timeout signal is emitted every interval without another input signal instead of just once.
--   **group_by**: The value by which signals are grouped. Output signals will have `group` set to this value.
-
-
-Dependencies
-----------------
-[GroupBy Block Mixin](https://github.com/nio-blocks/mixins/tree/master/group_by)
-
-Commands
-----------------
-None
-
-Input
--------
+Inputs
+------
 Any list of signals.
 
-Output
----------
-
+Outputs
+-------
 The last signal to enter the block will be notified as a timeout signal. The following two attributes will also be added to the signal.
-
 -   **timeout**: A python `datetime.timedelta` specifying the configured `interval` that triggered the timeout signal.
 -   **group**: The group as defined by `group_by`.
+
+Commands
+--------
+- **groups**: Display the active groups tracked by the block
+
+Dependencies
+------------
+[GroupBy Block Mixin](https://github.com/nio-blocks/mixins/tree/master/group_by)

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
   "nio/SignalTimeout": {
     "language": "Python",
-    "version": "0.0.1",
-    "reference": "github.com/nio-blocks/signal_timeout.git@v0.0.1"
+    "reference": "git@github.com:nio-blocks/signal_timeout.git@v0.1.0",
+    "version": "0.1.0"
   }
 }

--- a/signal_timeout_block.py
+++ b/signal_timeout_block.py
@@ -1,16 +1,11 @@
 from collections import defaultdict
-from nio.block.base import Block
-from nio.util.discovery import discoverable
-from nio.properties.timedelta import TimeDeltaProperty
-from nio.properties.bool import BoolProperty
-from nio.properties.list import ListProperty
-from nio.properties.holder import PropertyHolder
-from nio.properties.version import VersionProperty
-from nio.modules.scheduler import Job
 from threading import Event, Lock
-from nio.signal.base import Signal
-from nio.block.mixins.group_by.group_by import GroupBy
-from nio.block.mixins.persistence.persistence import Persistence
+
+from nio.block.base import Block
+from nio.properties import TimeDeltaProperty, BoolProperty, ListProperty, \
+    PropertyHolder, VersionProperty
+from nio.modules.scheduler import Job
+from nio.block.mixins import GroupBy, Persistence
 
 
 class Interval(PropertyHolder):
@@ -19,7 +14,6 @@ class Interval(PropertyHolder):
                               default=False)
 
 
-@discoverable
 class SignalTimeout(Persistence, GroupBy, Block):
 
     """ Notifies a timeout signal when no signals have been processed
@@ -86,9 +80,9 @@ class SignalTimeout(Persistence, GroupBy, Block):
             del self._repeatable_jobs[key]
 
     def _schedule_timeout_job(self, signal, key, interval, repeatable):
-        self.logger.debug("Scheduling new timeout job for group {}, interval"
-                           "={} repeatable={}".format(
-                               key, interval, repeatable))
+        self.logger.debug("Scheduling new timeout job for group {}, "
+                          "interval={} repeatable={}".format(
+                                key, interval, repeatable))
         self._jobs[key][interval] = Job(
             self._timeout_job, interval, repeatable, signal, key, interval)
         if repeatable:

--- a/spec.json
+++ b/spec.json
@@ -1,10 +1,34 @@
 {
   "nio/SignalTimeout": {
-    "version": "0.0.1",
-    "description": "",
+    "version": "0.1.0",
+    "description": "Notifies a timeout signal when no signals have been processed by this block for the defined `intervals`. A timeout signal is the last signal to enter the block with an added `group` attribute that specifies the group (default `None`) and a `timeout` attribute that is a python `datetime.timedelta` specifying the configured `interval` that triggered the signal.",
+    "properties": {
+      "group_by": {
+        "title": "Group By",
+        "type": "Type",
+        "description": "The value by which signals are grouped. Output signals will have `group` set to this value.",
+        "default": null
+      },
+      "intervals": {
+        "title": "Timeout Intervals",
+        "type": "ListType",
+        "description": "After a signal, if another one does not enter the block for this amount of time, emit a timeout signal.",
+        "default": []
+      },
+      "load_from_persistence": {
+        "title": "Load from Persistence?",
+        "type": "BoolType",
+        "description": "If true, when the block is restarted it will restart with the previous amount of remaining time for the current interval",
+        "default": true
+      }
+    },
     "inputs": {},
     "outputs": {},
-    "properties": {},
-    "commands": {}
+    "commands": {
+      "groups": {
+        "params": {},
+        "description": "Display the active groups tracked by the block"
+      }
+    }
   }
 }

--- a/spec.json
+++ b/spec.json
@@ -3,6 +3,14 @@
     "version": "0.1.0",
     "description": "Notifies a timeout signal when no signals have been processed by this block for the defined `intervals`. A timeout signal is the last signal to enter the block with an added `group` attribute that specifies the group (default `None`) and a `timeout` attribute that is a python `datetime.timedelta` specifying the configured `interval` that triggered the signal.",
     "properties": {
+      "backup_interval": {
+        "title": "Backup Interval",
+        "type": "TimeDeltaType",
+        "description": "How often to periodically save (backup) the persisted signal and interval.",
+        "default": {
+          "seconds": 3600
+        }
+      },
       "group_by": {
         "title": "Group By",
         "type": "Type",
@@ -26,8 +34,8 @@
     "outputs": {},
     "commands": {
       "groups": {
-        "params": {},
-        "description": "Display the active groups tracked by the block"
+        "description": "Display the active groups tracked by the block",
+        "params": {}
       }
     }
   }

--- a/tests/test_signal_timeout_block.py
+++ b/tests/test_signal_timeout_block.py
@@ -2,12 +2,14 @@ from collections import defaultdict
 import datetime
 from datetime import timedelta
 from threading import Event
+
 from nio.block.terminals import DEFAULT_TERMINAL
 from nio.modules.scheduler import Job
 from nio.util.threading import spawn
 from nio.signal.base import Signal
 from nio.testing.block_test_case import NIOBlockTestCase
 from nio.testing.modules.scheduler.scheduler import JumpAheadScheduler
+
 from ..signal_timeout_block import SignalTimeout
 
 
@@ -201,10 +203,10 @@ class TestSignalTimeout(NIOBlockTestCase):
         persisted_jobs[2][timedelta(seconds=0.1)] = Signal({"group": 2})
         block._repeatable_jobs = persisted_jobs
         self.configure_block(block, {
-            "intervals": [{"interval":
-                            {"milliseconds": 100},
-                            "repeatable": True
-                            }],
+            "intervals": [{
+                "interval": {"milliseconds": 100},
+                "repeatable": True
+            }],
             "group_by": "{{ $group }}"})
         block.start()
         self.assertEqual(len(block._jobs), 2)
@@ -258,10 +260,10 @@ class TestSignalTimeout(NIOBlockTestCase):
         persisted_jobs[2][timedelta(seconds=0.1)] = Signal({"group": 2})
         block._repeatable_jobs = persisted_jobs
         self.configure_block(block, {
-            "intervals": [{"interval":
-                            {"milliseconds": 100},
-                            "repeatable": True
-                            }],
+            "intervals": [{
+                "interval": {"milliseconds": 100},
+                "repeatable": True
+            }],
             "group_by": "{{ $group }}"})
         # This signal should not cancel the persisted job before it's scheduled
         spawn(block.process_signals, [Signal({"group": 2})])


### PR DESCRIPTION
The buildspec command pulled in a `Backup Interval` property
I was not sure what it was and did not see it in the block file, so I deleted this out of the spec. If I should put it back let me know!