### PR TITLE
Silence known error condition

### DIFF
--- a/signal_timeout_block.py
+++ b/signal_timeout_block.py
@@ -118,8 +118,8 @@ class SignalTimeout(Persistence, GroupBy, Block):
             try:
                 job.get('job', None).cancel()
             except AttributeError:
-                # ignore if no job included (when coming from persistence)
-                self.logger.warning("No job object found", exc_info=True)
+                # ignore if no job included (eg, when coming from persistence)
+                self.logger.info("No job object found, not cancelling")
 
     def _schedule_timeout_job(self, signal, group, interval, repeatable):
         self.logger.debug("Scheduling new timeout job for group {}, "


### PR DESCRIPTION
We expect to not have a job when loading from persistence, for some unknown reason I had it printing the stack trace and logging a warning when this happened. As a result we were seeing stack traces whenever starting a service with a persisted SignalTimeout block. It's a known condition so I lowered it to info level.